### PR TITLE
feat: allow a maximum container running at the same time for a single session

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -16,6 +16,8 @@ return [
     ],
 
     // maybe INPUT only for --network host ?
-    // not sure yet
     'firewall_chain' => 'DOCKER-USER',
+
+    // max container per on the php session opened
+    'max_per_session'       => 3,
 ];

--- a/config/config.php
+++ b/config/config.php
@@ -12,7 +12,8 @@ return [
     'limits' => [
         'memory'  => '512m',   // e.g. '512m', '2g', null = unlimited
         'cpus'    => '0.50',   // 0.5 CPU ⇒ 50 % of 1 core
-        'storage' => '1G',     // 1 GiB writable layer (needs devicemapper or fuse-overlayfs)
+        // FIXME: will still investigate why this does no work properly
+        //'storage' => '1G',     // 1 GiB writable layer (needs devicemapper or fuse-overlayfs)
     ],
 
     // maybe INPUT only for --network host ?

--- a/public/build.php
+++ b/public/build.php
@@ -4,6 +4,8 @@ use App\Sandbox;
 
 header('Content-Type: application/json');
 
+session_start();
+
 require __DIR__ . '/../vendor/autoload.php';
 $config = require __DIR__ . '/../config/config.php';
 
@@ -15,7 +17,7 @@ try {
     }
     Sandbox::cleanup($config['build_root'], $config['ttl_minutes']);
 
-    $sb   = new Sandbox($repo, $config);
+    $sb   = new Sandbox($repo, $config, session_id());
     $out  = $sb->run();          // ['log'=>..., 'ports'=>[]]
 
     echo json_encode([

--- a/public/build.php
+++ b/public/build.php
@@ -18,7 +18,7 @@ try {
     Sandbox::cleanup($config['build_root'], $config['ttl_minutes']);
 
     $sb   = new Sandbox($repo, $config, session_id());
-    $out  = $sb->run();          // ['log'=>..., 'ports'=>[]]
+    $out  = $sb->run();
 
     echo json_encode([
         'ok'    => true,

--- a/src/DockerManager.php
+++ b/src/DockerManager.php
@@ -49,7 +49,8 @@ class DockerManager
         $flags = [];
         if (!empty($this->limits['memory']))  $flags[] = '--memory='.escapeshellarg($this->limits['memory']);
         if (!empty($this->limits['cpus']))    $flags[] = '--cpus='.escapeshellarg($this->limits['cpus']);
-        if (!empty($this->limits['storage'])) $flags[] = '--storage-opt size='.escapeshellarg($this->limits['storage']);
+        // FIXME: will still investigate why this does no work properly
+        // if (!empty($this->limits['storage'])) $flags[] = '--storage-opt size='.escapeshellarg($this->limits['storage']);
         if (!$flags) return;
 
         foreach ($cids as $cid) {

--- a/src/Sandbox.php
+++ b/src/Sandbox.php
@@ -7,21 +7,37 @@ class Sandbox
     private string $id;
     private string $root;
     private string $workDir;
+    private string $sessionId;
+    private string $sessionFile;
+    private array  $cfg;
     private RepositoryManager $repo;
-    private DockerManager $docker;
+    private DockerManager     $docker;
 
-    public function __construct(string $repoUrl, array $cfg)
+    public function __construct(string $repoUrl, array $cfg, string $sessionId)
     {
-        $this->id      = Utils::uuid();
-        $this->root    = rtrim($cfg['build_root'], '/');
-        $this->workDir = $this->root . '/' . $this->id;
-        $this->repo    = new RepositoryManager($repoUrl, $this->workDir);
-        $this->docker  = new DockerManager(
+        $this->cfg       = $cfg;
+        $this->sessionId = preg_replace('/[^a-zA-Z0-9]/', '_', $sessionId);
+        $this->id        = Utils::uuid();
+        $this->root      = rtrim($cfg['build_root'], '/');
+        $this->workDir   = $this->root . '/' . $this->id;
+
+        $sesDir = $this->root . '/sessions/' . $this->sessionId;
+        if (!is_dir($sesDir)) mkdir($sesDir, 0777, true);
+        $active = glob("$sesDir/*");
+        $max    = $cfg['max_per_session'] ?? 3;
+        if (count($active) >= $max) {
+            throw new \RuntimeException("Limit reached: max $max concurrent sandboxes for this session.");
+        }
+        $this->sessionFile = $sesDir . '/' . $this->id . '.flag';
+
+        $this->repo   = new RepositoryManager($repoUrl, $this->workDir);
+        $this->docker = new DockerManager(
             $this->id,
             $this->workDir,
-            $cfg['container_ttl_seconds'] ?? 3600, // 1heure max
-            $cfg['limits'] ?? [],  // for specs per containers
-            $cfg['firewall_chain'] ?? 'DOCKER-USER' // still not sure on using INPUT instead
+            $cfg['container_ttl_seconds'] ?? 3600,
+            $cfg['limits']               ?? [],
+            $cfg['firewall_chain']       ?? 'DOCKER-USER',
+            $this->sessionFile
         );
     }
 
@@ -29,18 +45,20 @@ class Sandbox
     {
         $this->repo->clone();
         $buildInfo = $this->repo->locateBuildFile();
+        if (!$buildInfo) throw new \RuntimeException('No Dockerfile nor docker-compose.yml found');
 
-        if (!$buildInfo) {
-            throw new \RuntimeException('No Dockerfile nor docker-compose.yml found !');
-        }
-        return $this->docker->buildAndRun($buildInfo);
+        $out = $this->docker->buildAndRun($buildInfo);
+
+        // mark this sandbox as “running” for the session
+        file_put_contents($this->sessionFile, time());
+        return $out;
     }
 
-    /** simple GC run manually */
+    /** my custom garbage collector for old workdirs – unchanged */
     public static function cleanup(string $root, int $ttlMinutes): void
     {
         foreach (glob("$root/*") as $dir) {
-            if (!is_dir($dir)) continue;
+            if (!is_dir($dir) || basename($dir) === 'sessions') continue;
             if (filemtime($dir) < time() - $ttlMinutes * 60) {
                 shell_exec("rm -rf " . escapeshellarg($dir));
             }

--- a/src/Sandbox.php
+++ b/src/Sandbox.php
@@ -54,7 +54,7 @@ class Sandbox
         return $out;
     }
 
-    /** my custom garbage collector for old workdirs – unchanged */
+    /** my custom garbage collector for old workdirs */
     public static function cleanup(string $root, int $ttlMinutes): void
     {
         foreach (glob("$root/*") as $dir) {


### PR DESCRIPTION
## WHAT

- [x] On each request we session_start() and hand the PHP session‑ID to
Sandbox.
- [x] Sandbox keeps a small “flag” file in `builds/sessions/<sessionId>/<sandboxId>.flag`
- [ ] When the deferred cleaner runs (1 hour later or when containers exit) it
deletes the flag, instantly freeing a slot for the same session
